### PR TITLE
chore: change yq installation method to use wget

### DIFF
--- a/src/common-utils-extras/devcontainer-feature.json
+++ b/src/common-utils-extras/devcontainer-feature.json
@@ -1,7 +1,7 @@
 {
   "name": "Common Utilities Extras",
   "id": "common-utils-extras",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "More Common utilities for development containers",
   "installsAfter": [
     "ghcr.io/devcontainers/features/common-utils"

--- a/src/common-utils-extras/install.sh
+++ b/src/common-utils-extras/install.sh
@@ -36,10 +36,8 @@ sudo -iu $_REMOTE_USER <<EOF
 EOF
 
 # install yq
-sudo -iu $_REMOTE_USER <<EOF
-    sudo wget https://github.com/mikefarah/yq/releases/latest/download/yq_linux_$ARCH -O /usr/bin/yq &&\
-    sudo chmod +x /usr/bin/yq
-EOF
+sudo wget https://github.com/mikefarah/yq/releases/latest/download/yq_linux_$ARCH -O /usr/bin/yq 
+sudo chmod +x /usr/bin/yq
 
 # cleanup
 apt-get clean

--- a/src/common-utils-extras/install.sh
+++ b/src/common-utils-extras/install.sh
@@ -2,6 +2,9 @@
 
 set -eax
 
+ARCH=amd64
+if [ "$(uname -m)" = "aarch64" ]; then ARCH=arm64; fi
+
 # add repo for gum
 mkdir -p /etc/apt/keyrings
 curl -fsSL https://repo.charm.sh/apt/gpg.key | gpg --dearmor -o /etc/apt/keyrings/charm.gpg
@@ -34,7 +37,8 @@ EOF
 
 # install yq
 sudo -iu $_REMOTE_USER <<EOF
-    curl -sS https://webinstall.dev/yq | bash
+    wget https://github.com/mikefarah/yq/releases/latest/download/yq_linux_$ARCH -O /usr/bin/yq &&\
+    chmod +x /usr/bin/yq
 EOF
 
 # cleanup

--- a/src/common-utils-extras/install.sh
+++ b/src/common-utils-extras/install.sh
@@ -37,8 +37,8 @@ EOF
 
 # install yq
 sudo -iu $_REMOTE_USER <<EOF
-    wget https://github.com/mikefarah/yq/releases/latest/download/yq_linux_$ARCH -O /usr/bin/yq &&\
-    chmod +x /usr/bin/yq
+    sudo wget https://github.com/mikefarah/yq/releases/latest/download/yq_linux_$ARCH -O /usr/bin/yq &&\
+    sudo chmod +x /usr/bin/yq
 EOF
 
 # cleanup


### PR DESCRIPTION
This PR updates the installation method for `yq` in the `src/common-utils-extras/install.sh` script. The new method uses `wget` to download the latest version of `yq` directly from the GitHub releases page.

Changes:
- Updated the `yq` installation command to use `wget` for downloading the latest release.
- Ensured the downloaded binary is placed in `/usr/bin` and made executable.