### PR TITLE
Added bash completion for task

### DIFF
--- a/src/taskfile/devcontainer-feature.json
+++ b/src/taskfile/devcontainer-feature.json
@@ -1,7 +1,7 @@
 {
     "name": "Taskfile",
     "id": "taskfile",
-    "version": "1.0.0",
+    "version": "1.0.1",
     "description": "Taskfile is a task runner / build tool that aims to be simpler and easier to use than, for example, GNU Make.",
     "installsAfter": ["ghcr.io/devcontainers/features/common-utils"]
 }

--- a/src/taskfile/install.sh
+++ b/src/taskfile/install.sh
@@ -3,3 +3,5 @@
 set -eax
 
 sh -c "$(curl --location https://taskfile.dev/install.sh)" -- -d -b /usr/local/bin
+# Enable bash-completion for task
+/usr/local/bin/task --completion bash | sudo tee /etc/bash_completion.d/task > /dev/null


### PR DESCRIPTION
(Not familiar with the inner working of features, but it should be as easy as adding this additional command)

The idea is to have bash-completion for taskfile enabled by default, which is done by creating the task file in the /etc/bash_completion.d/ directory.

